### PR TITLE
add LD_LIBRARY_PATH env variable for nodejs8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ MAINTAINER alibaba-serverless-fc
 # Environment variables.
 ENV FC_SERVER_PATH=/var/fc/runtime/nodejs8 \
     NODE_PATH=/usr/local/lib/node_modules \
-    FC_FUNC_CODE_PATH=/code/ \
-    PATH=${FC_SERVER_PATH}/node_modules/.bin:${PATH}
+    FC_FUNC_CODE_PATH=/code
+ENV PATH=${FC_FUNC_CODE_PATH}/node_modules/.bin:${PATH}
+ENV LD_LIBRARY_PATH=${FC_FUNC_CODE_PATH}:${FC_FUNC_CODE_PATH}/lib
+
 # Create directory.
 RUN mkdir -p ${FC_SERVER_PATH}
 


### PR DESCRIPTION
增加 LD_LIBRARY_PATH 环境变量

并修改掉了 PATH 变量的一个 bug。
之前 PATH 环境定义如下
```
ENV FC_SERVER_PATH=/var/fc/runtime/nodejs4.4 \
     NODE_PATH=/usr/local/lib/node_modules \
    FC_FUNC_CODE_PATH=/code/ \
    PATH=${FC_SERVER_PATH}/node_modules/.bin:${PATH}
```
产生效果如下
/node_modules.bin: .....
这里有两个问题
1. ENV 指令的同一行里不可以使用`${}`引用前面的变量，不会报错，会产生空字符串。
2. `${FC_SERVER_PATH}/node_modules/.bin` 如果正确执行应该是 `/var/fc/runtime/nodejs4.4/node_modules/.bin` 这个目录是不存在的。我猜测初衷是指定 `/code/node_modules/.bin` ，于是改成了`ENV PATH=${FC_FUNC_CODE_PATH}/node_modules/.bin:${PATH}`
